### PR TITLE
Lucidic AI Integration

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -117,3 +117,5 @@ websockets==13.1
 wrapt==1.17.0
 yarl==1.18.3
 zipp==3.21.0
+
+lucidicai


### PR DESCRIPTION
This PR details what integrating with Lucidic AI's Agent Observability platform looks like for TheAgenticBrowser. 

Main Changes:
- lai.init() at the beginning of Orchestrator.run()
- lai.create_step() at the beginning of the step loop
- lai.create_event() and lai.end_event() around Pydantic calls (will be supported natively soon)
- The call to analyze the screenshot with ImageAnalyzer is natively captured since it uses the OpenAI SDK (no need to manually create event)
- lai.end_step() at the end of the step loop
- lai.reset() at the end of Orchestrator.run() -> This is equivalent to calling lai.end_session() + resetting for the next session